### PR TITLE
fix rust `edition` bug + update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 members = ["pbbs", "parlay", "enhanced_rayon", "multiqueue"]
 default-members = ["pbbs", "multiqueue"]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
 
 [workspace.dependencies]
 rayon   = "1.7.0"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ To get the full list of flags and arguments use `--help`:
 /path/to/build/directory/pbbs/release/dedup --help
 ```
 
+## Inputs
+
+All the benchmarks expect their data to be in the same format that PBBS uses.
+Please check [PBBS's website](https://cmuparlay.github.io/pbbsbench/) for instruction on how to generate input data.
+
 ## Example
 
 Run parallel dedup for 3 rounds on an input.

--- a/enhanced_rayon/Cargo.toml
+++ b/enhanced_rayon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "enhanced_rayon"
 version = "0.1.1"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 rayon.workspace = true

--- a/multiqueue/Cargo.toml
+++ b/multiqueue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multiqueue"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 rand = "*"

--- a/parlay/Cargo.toml
+++ b/parlay/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parlay"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 rayon.workspace = true

--- a/pbbs/Cargo.toml
+++ b/pbbs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name    = "pbbs"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 clap.workspace = true

--- a/pbbs/src/benchmarks/histogram/hist_time.rs
+++ b/pbbs/src/benchmarks/histogram/hist_time.rs
@@ -78,7 +78,7 @@ pub fn run(alg: Algs, rounds: usize, buckets: usize, arr: &[u32]) -> (Vec<u32>, 
         "hist",
         rounds,
         Duration::new(1, 0),
-        || { unsafe { *(r_ptr as *mut Vec<u32>) = vec![]; } },
+        || { unsafe { *(r_ptr as *mut Vec<u32>).as_mut().unwrap() = vec![]; } },
         || { f(&arr, buckets, &mut r); },
         || {}
     );

--- a/pbbs/src/benchmarks/remove_duplicates/dedup_time.rs
+++ b/pbbs/src/benchmarks/remove_duplicates/dedup_time.rs
@@ -49,7 +49,7 @@ pub fn run(alg: Algs, rounds: usize, arr: &[u32]) -> (Vec<u32>, Duration) {
         "dedup",
         rounds,
         Duration::new(1, 0),
-        || { unsafe { *(r_ptr as *mut Vec<u32>) = vec![]; } },
+        || { unsafe { *(r_ptr as *mut Vec<u32>).as_mut().unwrap() = vec![]; } },
         || { f(&arr, &mut r); },
         || {}
     );


### PR DESCRIPTION
@oooacaiooo found two issues when compiling with the latest versions of `rustc` (v1.78):
1. Not using the suggested resolver in the workspace.
2. An error in accessing pointers. This was ok in Rust v1.69.
Both are fixed in this commit.